### PR TITLE
Add missing dependencies and documentation for core oPacks

### DIFF
--- a/BouncyCastle/README.md
+++ b/BouncyCastle/README.md
@@ -1,0 +1,29 @@
+# BouncyCastle oPack
+
+Extra Java [BouncyCastle](https://www.bouncycastle.org/java.html) cryptography algorithms packaged for OpenAF. Installing the oPack
+adds the `bcprov`, `bcpkix`, and `bcutil` JARs to the runtime so that OpenAF automations can use newer TLS ciphers and PKI helpers
+without needing to manage the classpath manually.
+
+## Installation
+
+```bash
+opack install BouncyCastle
+```
+
+## Usage
+
+After installation you can rely on BouncyCastle classes directly from OpenAF scripts. For example the snippet below loads a PEM
+certificate and prints the public key algorithm:
+
+```javascript
+loadExternalJars(getOPackPath("BouncyCastle"));
+
+var pemReader = new Packages.org.bouncycastle.openssl.PEMParser(
+  io.readFileReader("server.crt")
+);
+var certHolder = pemReader.readObject();
+println(certHolder.getSubjectPublicKeyInfo().getAlgorithm().getAlgorithm());
+```
+
+Use this oPack whenever you need access to BouncyCastle primitives such as PKCS#12 parsing, certificate utilities, or extended TLS
+cipher suites inside OpenAF.

--- a/GCS/README.md
+++ b/GCS/README.md
@@ -1,0 +1,31 @@
+# GCS oPack
+
+OpenAF wrapper for Google Cloud Storage (GCS) built on top of the official Java client libraries. It simplifies connecting with
+service-account credentials and exposes helpers to list, inspect, and manipulate objects stored in buckets from OpenAF jobs.
+
+## Installation
+
+```bash
+opack install GCS
+```
+
+## Getting started
+
+1. Download a service-account JSON key with the necessary GCS permissions.
+2. Create a wrapper instance by passing the JSON file (or an equivalent map) to the constructor:
+
+```javascript
+loadLib("gcs.js");
+
+var gcs = new GCS("service-account.json");
+var objects = gcs.listObjects("my-bucket", "reports/", false, true);
+print(ow.format.toYAML(objects));
+```
+
+The `listObjects` helper mirrors `io.listFiles`, returning metadata such as size, storage class, and custom attributes. Additional
+methods let you probe object existence, read metadata, and generate presigned URLs as functionality is completed.
+
+## Notes
+
+The oPack bundles all transitive dependencies required by the `google-cloud-storage` Java client. No manual classpath management is
+necessary—once the oPack is installed every OpenAF runtime can immediately leverage the Storage API.

--- a/GCS/README.md
+++ b/GCS/README.md
@@ -19,7 +19,7 @@ loadLib("gcs.js");
 
 var gcs = new GCS("service-account.json");
 var objects = gcs.listObjects("my-bucket", "reports/", false, true);
-print(ow.format.toYAML(objects));
+yprint(objects);
 ```
 
 The `listObjects` helper mirrors `io.listFiles`, returning metadata such as size, storage class, and custom attributes. Additional

--- a/GoogleCompiler/README.md
+++ b/GoogleCompiler/README.md
@@ -11,18 +11,8 @@ opack install GoogleCompiler
 
 ## Usage
 
-```javascript
-loadLib("main.js");
-
-// Minify a script with advanced optimisations
-var compiler = require("GoogleCompiler");
-compiler.compile({
-  js: ["src/app.js"],
-  compilation_level: "ADVANCED",
-  language_out: "ECMASCRIPT_2020",
-  output_wrapper: "(function(){%output%})();",
-  js_output_file: "dist/app.min.js"
-});
+```sh
+opack exec GoogleCompiler --js hello.js --js_output_file hello-compiled.js
 ```
 
 See the Closure Compiler [flag reference](https://github.com/google/closure-compiler/wiki/Flags-and-Options) for all supported

--- a/GoogleCompiler/README.md
+++ b/GoogleCompiler/README.md
@@ -1,0 +1,29 @@
+# GoogleCompiler oPack
+
+Packages the Google Closure Compiler so you can minify and transpile JavaScript assets directly from OpenAF. The oPack exposes a
+simple wrapper that selects the appropriate compiler JAR (Java 8 or 11+) and forwards options to the Closure CLI.
+
+## Installation
+
+```bash
+opack install GoogleCompiler
+```
+
+## Usage
+
+```javascript
+loadLib("main.js");
+
+// Minify a script with advanced optimisations
+var compiler = require("GoogleCompiler");
+compiler.compile({
+  js: ["src/app.js"],
+  compilation_level: "ADVANCED",
+  language_out: "ECMASCRIPT_2020",
+  output_wrapper: "(function(){%output%})();",
+  js_output_file: "dist/app.min.js"
+});
+```
+
+See the Closure Compiler [flag reference](https://github.com/google/closure-compiler/wiki/Flags-and-Options) for all supported
+options. The wrapper simply prepares the process invocation, making it easy to embed into build oJobs.

--- a/Mac/README.md
+++ b/Mac/README.md
@@ -1,0 +1,29 @@
+# Mac oPack
+
+Utilities for working with macOS features from OpenAF. The bundle includes helpers for interacting with the native `say` command
+and converting Apple property list (plist) files to and from JavaScript objects using the dd-plist library.
+
+## Installation
+
+```bash
+opack install Mac
+```
+
+## Features
+
+* `macSay(message, voice, quiet)` — invoke the system speech synthesizer from scripts.
+* `af.fromPList(...)` / `af.toPList(...)` — convert between plist content and JavaScript objects/strings.
+* `io.readFilePList(...)` / `io.writeFilePList(...)` — load and persist plist files in XML or binary formats.
+
+## Example
+
+```javascript
+loadLib("mac.js");
+
+macSay("Automation complete", "Samantha");
+var plist = io.readFilePList("Settings.plist");
+plist.LastRun = new Date();
+io.writeFilePList("Settings.plist", plist);
+```
+
+These helpers remove the boilerplate needed to work with macOS configuration files when orchestrating local automations.

--- a/Redis/README.md
+++ b/Redis/README.md
@@ -1,0 +1,26 @@
+# Redis oPack
+
+Wrapper around the [Jedis](https://github.com/redis/jedis) client to provide a convenient Redis API for OpenAF scripts. Besides
+exposing the underlying Jedis object, the oPack includes helpers to manage keys, hashes, lists, sets, and sorted sets with native
+JavaScript data structures.
+
+## Installation
+
+```bash
+opack install Redis
+```
+
+## Quick start
+
+```javascript
+loadLib("redis.js");
+
+var redis = new Redis("localhost", 6379);
+redis.set("greeting", "hello world");
+print(redis.get("greeting"));
+print("Number of keys: " + redis.size());
+redis.close();
+```
+
+The wrapper automatically loads the bundled dependencies (`jedis`, `commons-pool2`, authentication helpers, and JSON support) so
+that you can focus on automation logic. For advanced scenarios call `redis.getObj()` to access the underlying Jedis instance.

--- a/SSHd/README.md
+++ b/SSHd/README.md
@@ -1,0 +1,24 @@
+# SSHd oPack
+
+Launch an embeddable SSH server using Apache MINA SSHD straight from OpenAF. Ideal for exposing temporary administrative shells,
+secure tunnels, or file operations that need to run within automation jobs.
+
+## Installation
+
+```bash
+opack install SSHd
+```
+
+## Example
+
+```javascript
+loadLib("sshd.js");
+
+var server = new SSHd(2222);
+server.setPasswordAuthenticator((user, pass, session) => user === "demo" && pass === "demo");
+server.start();
+println("SSHd listening on port 2222");
+```
+
+The helper exposes methods to configure password/public-key authentication, customise shell/command factories, and generate server
+keys. Call `server.stop()` to shut the listener down when the automation finishes.

--- a/Terraform/README.md
+++ b/Terraform/README.md
@@ -1,0 +1,25 @@
+# Terraform oPack
+
+Utilities to parse and generate HashiCorp Configuration Language (HCL) from OpenAF using the `hcl4j` parser. The toolkit eases
+integration with Terraform by allowing automations to read existing configuration files, manipulate them as JavaScript objects,
+and write the result back to disk.
+
+## Installation
+
+```bash
+opack install Terraform
+```
+
+## Sample workflow
+
+```javascript
+loadLib("terraform.js");
+
+var tf = new Terraform();
+var config = tf.fromHCL(io.readFileString("main.tf"));
+config.resource.aws_s3_bucket.example.tags.Environment = "ci";
+io.writeFileString("main.tf", tf.toHCL(config));
+```
+
+The companion `hcl.js` and `oafp_Terraform.js` files also expose helper commands to transform data structures to HCL from the
+command line (`oafp libs=Terraform`). Use whichever entrypoint fits your automation style.

--- a/cq/README.md
+++ b/cq/README.md
@@ -1,0 +1,27 @@
+# cq oPack
+
+Bindings for [Chronicle Queue](https://chronicle.software/products/chronicle-queue/) providing a persisted high-throughput queue
+that can be used from OpenAF. The oPack takes care of loading the extensive Chronicle dependency set and exposes a convenient
+wrapper for appending and reading JSON messages.
+
+## Installation
+
+```bash
+opack install cq
+```
+
+## Basic usage
+
+```javascript
+loadLib("cq.js");
+
+var queue = new CQ("./queue-data", "DAILY");
+queue.append({ event: "start", timestamp: Date.now() });
+queue.appendAll([{ event: "finish" }]);
+print(queue.size());
+print(ow.format.toYAML(queue.readAll()));
+queue.close(true);
+```
+
+You can also stream entries by calling `queue.forEach(fn)` and react to roll cycles via the constructor callback. This is useful
+for durable event logs or hand-offs between OpenAF jobs.

--- a/etcd3/README.md
+++ b/etcd3/README.md
@@ -1,0 +1,29 @@
+# etcd3 oPack
+
+Channel implementation backed by [etcd v3](https://etcd.io/) using IBM's `etcd-java` client. It enables OpenAF workflows to store
+state, watch keys, and coordinate jobs against an etcd cluster with minimal setup.
+
+## Installation
+
+```bash
+opack install etcd3
+```
+
+## Connecting
+
+```javascript
+loadLib("etcd3.js");
+
+ow.ch.use("etcd3");
+ow.ch.create("coordination", false, {
+  host: "127.0.0.1",
+  port: 2379,
+  namespace: "openaf/",
+  watch: true
+});
+
+ow.ch.set("coordination", "locks/demo", { owner: ow.server.getHostname(), at: Date.now() });
+```
+
+The channel exposes helpers such as `size`, `forEach`, `getAll`, `subscribe`, and automatic JSON encoding/decoding. Optional
+settings let you control namespaces, default values, or suppress exceptions when connectivity issues occur.

--- a/etcd3/README.md
+++ b/etcd3/README.md
@@ -14,15 +14,14 @@ opack install etcd3
 ```javascript
 loadLib("etcd3.js");
 
-ow.ch.use("etcd3");
-ow.ch.create("coordination", false, {
+$ch("coordination").create("etcd3", {
   host: "127.0.0.1",
   port: 2379,
   namespace: "openaf/",
   watch: true
 });
 
-ow.ch.set("coordination", "locks/demo", { owner: ow.server.getHostname(), at: Date.now() });
+$ch("coordination").set("locks/demo", { owner: ow.server.getHostname(), at: Date.now() });
 ```
 
 The channel exposes helpers such as `size`, `forEach`, `getAll`, `subscribe`, and automatic JSON encoding/decoding. Optional

--- a/jexer/README.md
+++ b/jexer/README.md
@@ -1,0 +1,24 @@
+# jexer oPack
+
+Bundles the [Jexer](https://gitlab.com/klamonte/jexer) text-mode UI toolkit so that OpenAF automations can present terminal user
+interfaces. The package exposes a lightweight wrapper that boots a `TApplication` with sensible defaults for XTerm-compatible
+terminals.
+
+## Installation
+
+```bash
+opack install jexer
+```
+
+## Usage
+
+```javascript
+loadLib("jexer.js");
+
+(new TApplication())
+  .addDefaults() // adds File/Tool/Window menus
+  .run();
+```
+
+From there you can use the standard Jexer APIs to add windows, forms, and dialogs. The oPack handles loading the JAR on demand so
+your scripts can stay focused on UI flow.

--- a/lanterna/README.md
+++ b/lanterna/README.md
@@ -1,0 +1,24 @@
+# Lanterna oPack
+
+Ships the [Lanterna](https://github.com/mabe02/lanterna) terminal UI framework for use within OpenAF. Combine it with your
+automations to build text-based dashboards, wizards, or data-entry forms that run in a console.
+
+## Installation
+
+```bash
+opack install lanterna
+```
+
+## Quick example
+
+```javascript
+loadExternalJars(getOPackPath("lanterna"));
+
+var terminal = new Packages.com.googlecode.lanterna.terminal.DefaultTerminalFactory().createTerminal();
+var screen = new Packages.com.googlecode.lanterna.screen.TerminalScreen(terminal);
+screen.startScreen();
+// build your GUI using Lanterna classes
+```
+
+The package only provides the JAR and a sample script; you can use the full Lanterna API to assemble multi-window interfaces,
+message dialogs, and interactive components.

--- a/plugin-GIT/README.md
+++ b/plugin-GIT/README.md
@@ -12,10 +12,10 @@ opack install plugin-GIT
 ## Example
 
 ```javascript
-Plugins.load("GIT");
+plugin("GIT");
 var git = new GIT("/tmp/repo", "user", "token");
 git.clone("https://github.com/example/repo.git", "/tmp/repo", true, null, "user", "token");
-print(ow.format.toYAML(git.status()));
+cprint(git.status());
 ```
 
 The plugin exposes the major JGit commands (clone, fetch, checkout, commit, push, etc.) via a JavaScript-friendly API. Use it to

--- a/plugin-GIT/README.md
+++ b/plugin-GIT/README.md
@@ -1,0 +1,22 @@
+# plugin-GIT oPack
+
+Provides an OpenAF plugin wrapping [JGit](https://www.eclipse.org/jgit/) so that repositories can be cloned, checked out, and
+managed from scripts. It supports initialising repositories, pushing/pulling with credentials, and inspecting status information.
+
+## Installation
+
+```bash
+opack install plugin-GIT
+```
+
+## Example
+
+```javascript
+Plugins.load("GIT");
+var git = new GIT("/tmp/repo", "user", "token");
+git.clone("https://github.com/example/repo.git", "/tmp/repo", true, null, "user", "token");
+print(ow.format.toYAML(git.status()));
+```
+
+The plugin exposes the major JGit commands (clone, fetch, checkout, commit, push, etc.) via a JavaScript-friendly API. Use it to
+automate repository maintenance or integrate Git operations into CI/CD oJobs.

--- a/plugin-Ignite/README.md
+++ b/plugin-Ignite/README.md
@@ -1,0 +1,23 @@
+# plugin-Ignite oPack
+
+OpenAF plugin that embeds [Apache Ignite](https://ignite.apache.org/) so jobs can use distributed caches, compute grids, and data
+structures. The plugin wraps core Ignite APIs and exports them through the OpenAF plugin mechanism.
+
+## Installation
+
+```bash
+opack install plugin-Ignite
+```
+
+## Example
+
+```javascript
+Plugins.load("Ignite");
+var ignite = new Ignite();
+var cache = ignite.getOrCreateCache("sessions");
+cache.put("user1", { lastSeen: Date.now() });
+print(cache.get("user1"));
+```
+
+Consult the generated OpenAF documentation (`opack doc plugin-Ignite`) for the full list of helpers around cache configuration,
+SQL queries, and cluster management. The oPack bundles `ignite-core`, `javax.cache`, and JetBrains annotations.

--- a/plugin-Ignite/README.md
+++ b/plugin-Ignite/README.md
@@ -12,11 +12,11 @@ opack install plugin-Ignite
 ## Example
 
 ```javascript
-Plugins.load("Ignite");
+plugin("Ignite");
 var ignite = new Ignite();
 var cache = ignite.getOrCreateCache("sessions");
 cache.put("user1", { lastSeen: Date.now() });
-print(cache.get("user1"));
+cprint(cache.get("user1"));
 ```
 
 Consult the generated OpenAF documentation (`opack doc plugin-Ignite`) for the full list of helpers around cache configuration,

--- a/plugin-SMB/README.md
+++ b/plugin-SMB/README.md
@@ -1,0 +1,22 @@
+# plugin-SMB oPack
+
+OpenAF plugin to access SMB/CIFS (Windows file sharing) resources using the jcifs-ng library. It provides convenient wrappers to
+list, read, and write files on remote shares directly from automations.
+
+## Installation
+
+```bash
+opack install plugin-SMB
+```
+
+## Example
+
+```javascript
+Plugins.load("SMB");
+var smb = new SMB("smb://fileserver/share", "DOMAIN\\user", "password");
+print(smb.list("/"));
+smb.copyTo("/reports/monthly.xlsx", "./monthly.xlsx");
+```
+
+The plugin supports authenticated access (including domain notation) and relies on BouncyCastle for modern security defaults. Use
+it to orchestrate file exchanges with legacy Windows services without shelling out to external tools.

--- a/plugin-SMB/README.md
+++ b/plugin-SMB/README.md
@@ -12,9 +12,9 @@ opack install plugin-SMB
 ## Example
 
 ```javascript
-Plugins.load("SMB");
+plugin("SMB");
 var smb = new SMB("smb://fileserver/share", "DOMAIN\\user", "password");
-print(smb.list("/"));
+cprint(smb.list("/"));
 smb.copyTo("/reports/monthly.xlsx", "./monthly.xlsx");
 ```
 

--- a/plugin-SVN/README.md
+++ b/plugin-SVN/README.md
@@ -12,10 +12,10 @@ opack install plugin-SVN
 ## Example
 
 ```javascript
-Plugins.load("SVN");
+plugin("SVN");
 var svn = new SVN("https://svn.example.com/repos/project", "user", "pass");
 svn.checkout("trunk", "/tmp/project");
-print(svn.list("trunk"));
+cprint(svn.list("trunk"));
 ```
 
 The plugin includes both `svnkit` and `svnkit-cli` so you can perform common commands like checkout, update, commit, and branch

--- a/plugin-SVN/README.md
+++ b/plugin-SVN/README.md
@@ -1,0 +1,22 @@
+# plugin-SVN oPack
+
+Provides an OpenAF plugin built on top of [SVNKit](https://svnkit.com/) so Subversion repositories can be automated alongside
+other tasks. Ideal for environments that still rely on SVN but want to orchestrate operations through OpenAF.
+
+## Installation
+
+```bash
+opack install plugin-SVN
+```
+
+## Example
+
+```javascript
+Plugins.load("SVN");
+var svn = new SVN("https://svn.example.com/repos/project", "user", "pass");
+svn.checkout("trunk", "/tmp/project");
+print(svn.list("trunk"));
+```
+
+The plugin includes both `svnkit` and `svnkit-cli` so you can perform common commands like checkout, update, commit, and branch
+management without shelling out to native binaries.

--- a/plugin-XLS/README.md
+++ b/plugin-XLS/README.md
@@ -1,0 +1,23 @@
+# plugin-XLS oPack
+
+OpenAF plugin exposing Apache POI to create, read, and manipulate Excel workbooks. It bundles all required POI components
+(`poi`, `poi-ooxml`, `xmlbeans`, etc.) along with convenience helpers packaged as an OpenAF plugin.
+
+## Installation
+
+```bash
+opack install plugin-XLS
+```
+
+## Example
+
+```javascript
+Plugins.load("XLS");
+var xls = new XLS();
+var workbook = xls.open("template.xlsx");
+workbook.setValue("Sheet1", 1, 1, "Hello from OpenAF!");
+workbook.saveAs("output.xlsx");
+```
+
+Use the plugin to automate report generation, spreadsheet ingestion, or XLSX transformations without having to manage POI
+manually.

--- a/plugin-XLS/README.md
+++ b/plugin-XLS/README.md
@@ -12,7 +12,7 @@ opack install plugin-XLS
 ## Example
 
 ```javascript
-Plugins.load("XLS");
+plugin("XLS");
 var xls = new XLS();
 var workbook = xls.open("template.xlsx");
 workbook.setValue("Sheet1", 1, 1, "Hello from OpenAF!");

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,17 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.81</version>
+            <version>1.82</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.82</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
+            <version>1.82</version>
         </dependency>
         <dependency>
             <groupId>eu.agno3.jcifs</groupId>
@@ -90,12 +100,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.24.3</version>
+            <version>2.25.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.24.3</version>
+            <version>2.25.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
@@ -128,14 +138,14 @@
             <version>7.4.0</version>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.81</version>
-        </dependency>
-        <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
             <version>8.5.17</version>
+        </dependency>
+        <dependency>
+            <groupId>com.gitlab.klamonte</groupId>
+            <artifactId>jexer</artifactId>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ignite</groupId>
@@ -188,9 +198,49 @@
             <version>7.3.0.202506031305-r</version>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>4.1.127.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.127.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-dns</artifactId>
+            <version>4.1.127.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-socks</artifactId>
+            <version>4.1.127.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <version>4.1.127.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+            <version>4.1.127.Final</version>
+        </dependency>
+        <dependency>
             <groupId>com.googlecode.plist</groupId>
             <artifactId>dd-plist</artifactId>
             <version>1.28</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.zxing</groupId>
+            <artifactId>core</artifactId>
+            <version>3.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.zxing</groupId>
+            <artifactId>javase</artifactId>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
@@ -206,6 +256,21 @@
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-queue</artifactId>
             <version>5.27ea9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.lanterna</groupId>
+            <artifactId>lanterna</artifactId>
+            <version>3.2.0-alpha1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.38</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>24.1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/rocksdb/README.md
+++ b/rocksdb/README.md
@@ -1,0 +1,23 @@
+# RocksDB oPack
+
+Channel utilities for [RocksDB](https://rocksdb.org/). The oPack bundles the native `rocksdbjni` library and augments the
+`ow.ch` channel implementation with helpers to inspect live options, read statistics, and clean log directories for RocksDB-based
+stores.
+
+## Installation
+
+```bash
+opack install rocksdb
+```
+
+## Usage
+
+```javascript
+loadLib("rocksdb.js");
+ow.ch.use("rocksdb");
+ow.ch.create("state", false, { path: "./db" });
+print(ow.ch.utils.rocksdb.liveStats("state"));
+```
+
+Use `ow.ch.utils.rocksdb.cleanDir(path)` to remove stale log files and `liveOptions/liveDBOptions` to introspect configuration
+applied to running databases. All JNI dependencies are loaded automatically when the oPack is installed.

--- a/rocksdb/README.md
+++ b/rocksdb/README.md
@@ -14,8 +14,7 @@ opack install rocksdb
 
 ```javascript
 loadLib("rocksdb.js");
-ow.ch.use("rocksdb");
-ow.ch.create("state", false, { path: "./db" });
+$ch("state").create("rocksdb", { path: "./db" });
 print(ow.ch.utils.rocksdb.liveStats("state"));
 ```
 


### PR DESCRIPTION
## Summary
- add missing Maven dependencies for bundled libraries such as BouncyCastle, Netty, ZXing, Lanterna, Lombok, and JetBrains annotations
- upgrade Log4j to 2.25.0 to align with the XLS plugin requirements
- document core oPacks with new READMEs covering installation and usage guidance

## Testing
- not run (not requested)
