### PR TITLE
Add optional vector search to Lucene `searchdb`

### DIFF
--- a/lucene/.package.yaml
+++ b/lucene/.package.yaml
@@ -21,7 +21,7 @@ name: lucene
 main: ''
 mainJob: ''
 license: https://github.com/OpenAF/openaf-opacks/blob/master/LICENSE
-version: '20260706'
+version: '20260726'
 dependencies:
   openaf: '>=20250926'
 files:
@@ -42,14 +42,14 @@ files:
 filesHash:
   .maven.yaml: a403c731c6eb0e251c0747ba11bfd0c7b6d5683e
   .odoc.db: 7b8dfc21edad884f6a066b7db024cdd12e2deb8d
-  README.md: 0a1af96b918a2c2a67238d098b5b50df811d84b3
+  README.md: 7129357ed09dc3825ed914d0fea624d2eadd2814
   lucene-analysis-common-10.5.0.jar: 2b314f57f18f3d9ad855f611f6f391519ac78a8d
   lucene-core-10.5.0.jar: 383deeee9b44ef15daaf7541d57ea5183d52a7b5
   lucene-facet-10.5.0.jar: cd4d1febfe5c3afa1d5baf8e2e33425784d0a7a6
   lucene-queries-10.5.0.jar: c96555ec32a411d860527ea13add388d72a614b2
   lucene-queryparser-10.5.0.jar: dea0c58101825f086127abf5adce13ced0bd0fc2
   lucene-sandbox-10.5.0.jar: 928527693dc814ba0125659b07316e260713e38f
-  lucene.js: cdac3483a4cb6b18e7d4474e4a8222401658c7f9
+  lucene.js: 7d25f29bfbca9c8f4b4102291a462cd16de34ee3
   oJobLucene.yaml: 91bb37c691b95e357c0518a790ce12951593bffb
-  tests/autoTestLucene.js: 0eddd736f9f84002b7ccab5d279c5969b734e34a
-  tests/autoTestLucene.yaml: 4566dffa15732b5e16ef0e4bf3e6d6e7a076ed29
+  tests/autoTestLucene.js: 63479f71a9d6adbb09bc5f38d1ed8af0a7bc8ac3
+  tests/autoTestLucene.yaml: ab9e5da57b6087040ee90319afc883e74f18e1cf

--- a/lucene/README.md
+++ b/lucene/README.md
@@ -24,17 +24,8 @@ $ch("embeddings").create("vectordb", {
 })
 
 var embedText = function(text) {
-  var llm
-  try {
-    // Example: OAF_MODEL="(type: ollama, model: 'embeddinggemma:latest', url: 'http://ollama.local:11434', timeout: 900000)"
-    llm = $llm(af.fromJSSLON(getEnv("OAF_MODEL")))
-    var r = llm.getEmbeddings(text, 384)
-    if (isDef(r) && isDef(r.data) && isDef(r.data[0].embedding)) return r.data[0].embedding
-    if (isDef(r) && isDef(r.embeddings)) return r.embeddings[0]
-    return r
-  } finally {
-    if (isDef(llm)) llm.close()
-  }
+  // Supplied by the application. It may call any local or remote embedding service.
+  return applicationEmbeddingProvider.embed(text)
 }
 
 $ch("embeddings").set({ id: "doc-1" }, {
@@ -112,6 +103,73 @@ cprint(hits)
 - `analyzer` *(String|Map, optional; default `standard`)*: Analyzer preset (`standard`, `keyword`, `whitespace`, `english`).
 - `autoCommit` *(Boolean, optional; default `true`)*: Commit on writes.
 - `autoRefresh` *(Boolean, optional; default `true`)*: Refresh searcher on writes.
+
+### Optional vectors in `searchdb`
+
+Text-only indexes remain the default. To add vectors to the same documents, explicitly
+set `vectorDimension`. This adds a Lucene `KnnFloatVectorField` without changing the
+existing ID, content, payload, typed-field, facet, or BM25 behavior.
+
+```javascript
+var provider = {
+  embed: function(text) {
+    // Embedding generation belongs to the application; return a plain number array.
+    return applicationEmbeddingFunction(text)
+  }
+}
+
+$ch("docs").create("searchdb", {
+  path: "./data/docs-index",
+  vectorDimension: 384,
+  vectorField: "vector",             // optional; default "vector"
+  vectorSimilarity: "cosine",        // cosine, dot_product, or euclidean
+  embeddingProvider: provider         // optional function or { embed: function(text) }
+})
+
+// Supply a vector directly. Documents are still indexed for normal text search.
+$ch("docs").set({ id: "doc-1" }, {
+  content: "Apache Lucene supports text and vector retrieval.",
+  payload: { source: "guide" },
+  vector: provider.embed("Apache Lucene supports text and vector retrieval.")
+})
+
+// When embeddingProvider is configured, omitting vector embeds the document content.
+$ch("docs").set({ id: "doc-2" }, {
+  content: "The application controls embedding generation."
+})
+```
+
+Documents may omit vectors when no provider is configured; they remain available to
+text search but are not k-NN candidates. Vector dimensions and all elements are
+validated. Opening an existing text-only index with vector options is supported, but
+only newly written vector-bearing documents participate in vector retrieval.
+
+Use `getAll({ vector, k })` through the channel API, or call the channel type's explicit
+methods when building a lower-level wrapper:
+
+```javascript
+var queryVector = provider.embed("combined retrieval")
+
+// Existing BM25 API is unchanged.
+var textHits = $ch("docs").getAll({ query: "combined retrieval", limit: 10 })
+
+// k-NN search.
+var vectorHits = $ch("docs").getAll({ vector: queryVector, k: 10 })
+// Equivalent low-level method:
+var sameHits = ow.ch.__types.searchdb.vectorSearch("docs", queryVector, 10)
+
+// Merge and normalize BM25 and vector scores, then rerank with equal weights.
+var hybridHits = ow.ch.__types.searchdb.hybridSearch("docs", {
+  query: "combined retrieval",
+  vector: queryVector,
+  k: 20,
+  weights: { text: 0.5, vector: 0.5 }
+})
+```
+
+The existing advanced `getAll({ hybrid: ... })` form remains supported, including a
+separate `vectorChannel`. When the current `searchdb` is vector-enabled, `hybrid.vector`
+is searched locally if no `vectorChannel` or precomputed `vectorResults` is supplied.
 
 ### `searchdb` advanced write format
 

--- a/lucene/lucene.js
+++ b/lucene/lucene.js
@@ -468,6 +468,46 @@ ow.ch.__types.searchdb = {
         if (isUnDef(v)) return []
         return isArray(v) ? v : [v]
     },
+    __vectorEnabled: function(channel) {
+        return isDef(channel.options.vectorDimension)
+    },
+    __vectorSimilarity: function(name) {
+        switch(String(name || "cosine").toLowerCase()) {
+        case "dot":
+        case "dot_product":
+            return Packages.org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT
+        case "l2":
+        case "euclidean":
+            return Packages.org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN
+        case "cos":
+        case "cosine":
+            return Packages.org.apache.lucene.index.VectorSimilarityFunction.COSINE
+        default:
+            throw new Error("Unsupported vector similarity '" + name + "'. Use cosine, dot_product or euclidean.")
+        }
+    },
+    __validateVector: function(channel, vector, label) {
+        label = label || "vector"
+        if (!this.__vectorEnabled(channel)) throw new Error("Vector search is not enabled for this searchdb index. Set options.vectorDimension when creating it.")
+        if (!isArray(vector)) throw new Error(label + " must be an array of finite numbers.")
+        if (vector.length != channel.options.vectorDimension) throw new Error(label + " dimension mismatch. Expected " + channel.options.vectorDimension + " but got " + vector.length + ".")
+        var out = java.lang.reflect.Array.newInstance(java.lang.Float.TYPE, vector.length)
+        for (var i = 0; i < vector.length; i++) {
+            if (!isNumber(vector[i]) || !isFinite(Number(vector[i]))) throw new Error(label + " contains a non-finite number at position " + i + ".")
+            out[i] = java.lang.Float.valueOf(Number(vector[i])).floatValue()
+        }
+        return out
+    },
+    __providedVector: function(channel, value, content) {
+        var vector = (this.__isObj(value) && isDef(value.vector)) ? value.vector : __
+        if (isUnDef(vector) && isDef(channel.options.embeddingProvider)) {
+            var provider = channel.options.embeddingProvider
+            if (isFunction(provider)) vector = provider(content, value)
+            else if (this.__isObj(provider) && isFunction(provider.embed)) vector = provider.embed(content)
+            else throw new Error("options.embeddingProvider must be a function or an object with an embed(text) function.")
+        }
+        return vector
+    },
     __toAnalyzer: function(opts) {
         var a = this.__isObj(opts.analyzer) ? opts.analyzer : { preset: opts.analyzer }
         var preset = String(_$(a.preset, "analyzer.preset").default("standard")).toLowerCase()
@@ -508,7 +548,7 @@ ow.ch.__types.searchdb = {
                 var keys = Object.keys(value)
                 for (var i = 0; i < keys.length; i++) {
                     var k = keys[i]
-                    if (k == contentField || k == "content" || k == "text" || k == "payload" || k == "fields" || k == "facets" || k == channel.options.idField) continue
+                    if (k == contentField || k == "content" || k == "text" || k == "payload" || k == "fields" || k == "facets" || k == channel.options.idField || (this.__vectorEnabled(channel) && k == "vector")) continue
                     payload[k] = value[k]
                 }
             }
@@ -533,7 +573,7 @@ ow.ch.__types.searchdb = {
             }
         }
 
-        return { content: content, payload: payload, fields: fields, facets: facets }
+        return { content: content, payload: payload, fields: fields, facets: facets, vector: this.__providedVector(channel, value, content) }
     },
     __addTypedField: function(doc, fieldName, fieldType, fieldValue) {
         if (isUnDef(fieldValue)) return
@@ -582,6 +622,10 @@ ow.ch.__types.searchdb = {
         doc.add(new Packages.org.apache.lucene.document.StringField(channel.options.idField, keyValue, Packages.org.apache.lucene.document.Field.Store.YES))
         doc.add(new Packages.org.apache.lucene.document.TextField(channel.options.contentField, extracted.content, Packages.org.apache.lucene.document.Field.Store.YES))
         doc.add(new Packages.org.apache.lucene.document.StoredField(channel.options.payloadField, stringify(extracted.payload, void 0, "")))
+        if (isDef(extracted.vector)) {
+            var vector = this.__validateVector(channel, extracted.vector, "document vector")
+            doc.add(new Packages.org.apache.lucene.document.KnnFloatVectorField(channel.options.vectorField, vector, channel.vectorSimilarity))
+        }
 
         var fieldKeys = Object.keys(extracted.fields)
         for (var i = 0; i < fieldKeys.length; i++) {
@@ -1071,6 +1115,8 @@ ow.ch.__types.searchdb = {
         if (isDef(hybrid.vectorResults) && isArray(hybrid.vectorResults)) vectorHits = hybrid.vectorResults
         else if (isDef(hybrid.vectorChannel) && isDef(hybrid.vector) && isArray(hybrid.vector)) {
             vectorHits = $ch(String(hybrid.vectorChannel)).getAll({ vector: hybrid.vector, k: Number(_$(hybrid.kVector, "hybrid.kVector").default(50)) })
+        } else if (isDef(hybrid.vector) && isArray(hybrid.vector) && this.__vectorEnabled(channel)) {
+            vectorHits = this.vectorSearch(aName, hybrid.vector, Number(_$(hybrid.kVector, "hybrid.kVector").default(hybrid.k || 50)))
         }
 
         for (i = 0; i < vectorHits.length; i++) {
@@ -1160,6 +1206,14 @@ ow.ch.__types.searchdb = {
         options.defaultSortField = _$(options.defaultSortField, "options.defaultSortField").default(__)
         options.analyzer = _$(options.analyzer, "options.analyzer").default("standard")
         options.taxonomyPath = _$(options.taxonomyPath, "options.taxonomyPath").isString().default(options.path + "/_taxonomy")
+        if (isDef(options.dimension) && isUnDef(options.vectorDimension)) options.vectorDimension = options.dimension
+        if (isDef(options.vectorDimension)) {
+            options.vectorDimension = Number(options.vectorDimension)
+            if (!isFinite(options.vectorDimension) || options.vectorDimension <= 0 || Math.floor(options.vectorDimension) != options.vectorDimension) throw new Error("options.vectorDimension must be a positive integer.")
+            options.vectorField = _$(options.vectorField, "options.vectorField").isString().default("vector")
+            options.vectorSimilarity = _$(options.vectorSimilarity, "options.vectorSimilarity").default("cosine")
+            if (isDef(options.embeddingProvider) && !isFunction(options.embeddingProvider) && !(this.__isObj(options.embeddingProvider) && isFunction(options.embeddingProvider.embed))) throw new Error("options.embeddingProvider must be a function or an object with an embed(text) function.")
+        }
 
         if (!io.fileExists(options.path)) io.mkdir(options.path)
         if (options.facetFields.length > 0 && !io.fileExists(options.taxonomyPath)) io.mkdir(options.taxonomyPath)
@@ -1188,7 +1242,8 @@ ow.ch.__types.searchdb = {
             facetsConfig: facetsConfig,
             taxoDirectory: taxoDirectory,
             taxoWriter: taxoWriter,
-            options: options
+            options: options,
+            vectorSimilarity: isDef(options.vectorDimension) ? this.__vectorSimilarity(options.vectorSimilarity) : __
         }
     },
     destroy: function(aName) {
@@ -1218,6 +1273,7 @@ ow.ch.__types.searchdb = {
     getAll: function(aName, full) {
         var channel = this.__ensureChannel(aName)
         if (this.__isObj(full) && this.__isObj(full.hybrid)) return this.__withMeta(this.__runHybrid(aName, full))
+        if (this.__isObj(full) && isDef(full.vector) && isUnDef(full.query)) return this.vectorSearch(aName, full.vector, full.k)
         this.__refresh(channel)
         var searcher = channel.searcherManager.acquire()
         try {
@@ -1336,6 +1392,37 @@ ow.ch.__types.searchdb = {
         var full = { query: (isString(q) ? String(q) : q), limit: Number(isDef(limit) ? limit : 20) }
         var r = this.getAll(aName, full)
         return this.__isObj(r) ? r.hits : r
+    },
+    vectorSearch: function(aName, vector, k) {
+        var channel = this.__ensureChannel(aName)
+        var queryVector = this.__validateVector(channel, vector, "query vector")
+        k = Number(isDef(k) ? k : 10)
+        if (!isFinite(k) || k <= 0 || Math.floor(k) != k) throw new Error("k must be a positive integer.")
+        this.__refresh(channel)
+        var searcher = channel.searcherManager.acquire()
+        try {
+            var query = new Packages.org.apache.lucene.search.KnnFloatVectorQuery(channel.options.vectorField, queryVector, k)
+            var topDocs
+            try {
+                topDocs = searcher.search(query, k)
+            } catch(e) {
+                throw new Error("Unable to search vector field '" + channel.options.vectorField + "'. The existing index may be incompatible with the configured vector dimension or similarity: " + e)
+            }
+            var out = []
+            for (var i = 0; i < topDocs.scoreDocs.length; i++) {
+                var doc = this.__getDocument(searcher, topDocs.scoreDocs[i].doc)
+                if (isDef(doc)) out.push(this.__toObj(channel, doc, topDocs.scoreDocs[i].score))
+            }
+            return out
+        } finally {
+            channel.searcherManager.release(searcher)
+        }
+    },
+    hybridSearch: function(aName, options) {
+        options = _$(options, "options").isMap().$_()
+        if (isUnDef(options.vector)) throw new Error("options.vector is required for hybrid search.")
+        var full = { query: options.query, hybrid: { textQuery: options.query, vector: options.vector, kText: options.kText || options.k, kVector: options.kVector || options.k, weights: options.weights }, limit: options.limit || options.k || 20 }
+        return this.__runHybrid(aName, full).hits
     }
 }
 

--- a/lucene/tests/autoTestLucene.js
+++ b/lucene/tests/autoTestLucene.js
@@ -99,6 +99,40 @@
     }
   }
 
+  exports.testSearchDBVectors = function() {
+    var chName = "luceneSearchdbVectorsTest"
+    var dbPath = basePath + "/searchdb-vectors"
+
+    cleanPath(basePath)
+    io.mkdir(basePath)
+    $ch(chName).create("searchdb", {
+      path: dbPath,
+      vectorDimension: 3,
+      embeddingProvider: { embed: function(text) { return text.indexOf("alpha") >= 0 ? [1, 0, 0] : [0, 1, 0] } }
+    })
+
+    try {
+      $ch(chName).set({ id: "doc-a" }, { content: "alpha document", payload: { kind: "direct" }, vector: [1, 0, 0] })
+      $ch(chName).set({ id: "doc-b" }, { content: "beta document", payload: { kind: "provider" } })
+
+      var vectorHits = ow.ch.__types.searchdb.vectorSearch(chName, [0, 1, 0], 2)
+      ow.test.assert(String(vectorHits[0].id), "doc-b", "integrated vector search should rank the provider vector first")
+
+      var getAllHits = $ch(chName).getAll({ vector: [1, 0, 0], k: 1 })
+      ow.test.assert(String(getAllHits[0].id), "doc-a", "getAll should expose optional vector search")
+
+      var hybrid = ow.ch.__types.searchdb.hybridSearch(chName, { query: "alpha", vector: [0, 1, 0], k: 2 })
+      ow.test.assert(hybrid.length, 2, "hybrid search should merge text and vector candidates")
+
+      var dimensionError = false
+      try { ow.ch.__types.searchdb.vectorSearch(chName, [1, 0], 1) } catch(e) { dimensionError = String(e).indexOf("Expected 3") >= 0 }
+      ow.test.assert(dimensionError, true, "vector search should clearly reject a dimension mismatch")
+    } finally {
+      $ch(chName).destroy()
+      cleanPath(basePath)
+    }
+  }
+
   exports.testSearchDBAdvanced = function() {
     var chName = "luceneSearchdbAdvancedTest"
     var dbPath = basePath + "/searchdb-advanced"

--- a/lucene/tests/autoTestLucene.yaml
+++ b/lucene/tests/autoTestLucene.yaml
@@ -9,6 +9,7 @@ ojob:
 todo:
 - lucene::VectorDB
 - lucene::SearchDBChannel
+- lucene::SearchDBVectors
 - lucene::SearchDBAdvanced
 - lucene::SearchDBHelper
 - lucene::SearchDBHelperFileOps
@@ -35,6 +36,11 @@ jobs:
   to  : oJob Test
   exec: args.func = args.tests.testSearchDBAdvanced
 
+- name: lucene::SearchDBVectors
+  from: lucene::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testSearchDBVectors
+
 - name: lucene::SearchDBHelper
   from: lucene::Init
   to  : oJob Test
@@ -50,6 +56,7 @@ jobs:
   deps:
   - lucene::VectorDB
   - lucene::SearchDBChannel
+  - lucene::SearchDBVectors
   - lucene::SearchDBAdvanced
   - lucene::SearchDBHelper
   - lucene::SearchDBHelperFileOps


### PR DESCRIPTION
### Motivation

- Add opt-in dense vector support to the existing `searchdb` channel so applications can perform k-NN and hybrid retrieval without changing any existing BM25/text-search behavior. 
- Keep the oPack embedding-model agnostic by accepting caller-supplied vectors or a user-provided embedding callback rather than generating embeddings internally. 
- Validate vectors and surface clear errors when vectors are missing, wrong-dimensioned, or incompatible with an existing index.

### Description

- Introduced vector handling helpers and validation in `lucene.js`, including `__vectorEnabled`, `__vectorSimilarity`, `__validateVector`, and `__providedVector` to keep vector logic separated and opt-in. 
- Extended the `searchdb` create options to accept `vectorDimension` (alias `dimension`), `vectorField`, `vectorSimilarity`, and `embeddingProvider`, and validated these options when opening the index. 
- Plumbed vectors through document creation: `__extractValue` now collects a `vector` (either provided inline or produced via `embeddingProvider`) and `__documentFrom` stores vectors in a Lucene `KnnFloatVectorField` while preserving all existing ID/content/payload/schema/facet fields. 
- Added APIs for k-NN and hybrid retrieval: channel `getAll({ vector, k })` supports k-NN queries; low-level `vectorSearch(aName, vector, k)` and `hybridSearch(aName, options)` were added to `ow.ch.__types.searchdb` and hybrid fusion is implemented by merging and normalizing BM25 and vector scores. 
- Kept full backwards compatibility: text-only indexes and existing APIs remain unchanged when `vectorDimension` is not set, and vector-enabled indexes are opt-in. 
- Documentation updates in `README.md` that explain how to enable vectors, how to supply vectors or embedding providers, and how to run text, vector, and hybrid searches. 
- Added unit tests and test job wiring: new test `testSearchDBVectors` in `tests/autoTestLucene.js` and test job entry in `tests/autoTestLucene.yaml`. 
- Updated package metadata version in `.package.yaml` and regenerated package hashes.

### Testing

- Ran the repository's direct OpenAF test harness via: `ow.loadTest(); var t=require("tests/autoTestLucene.js"); Object.keys(t).forEach(function(k){ print("Running " + k); t[k]() })`, which executed all exported tests (`testVectorDB`, `testSearchDBChannel`, `testSearchDBVectors`, `testSearchDBAdvanced`, `testSearchDBHelper`, `testSearchDBHelperFileOps`) and completed successfully. 
- Generated the package with `opack genpack .` to refresh `.package.yaml` hashes, which completed successfully. 
- Attempted the oJob orchestration `ojob tests/autoTestLucene.yaml`, which could not run in the environment because the `oJob-common` dependency was not available on the configured remote opack database; as a result the test job runner could not be used, so the full test suite was executed directly with OpenAF as shown above (and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a662dece0d48332a6ab02872bddb133)